### PR TITLE
Fix unintialized pn532_is_ready ptr for uart

### DIFF
--- a/src/pn532_driver_hsu.c
+++ b/src/pn532_driver_hsu.c
@@ -74,6 +74,7 @@ esp_err_t pn532_new_driver_hsu(gpio_num_t uart_rx,
     io_handle->pn532_read = pn532_read;
     io_handle->pn532_write = pn532_write;
     io_handle->pn532_init_extra = pn532_init_extra;
+    io_handle->pn532_is_ready = NULL;
 
 #ifdef CONFIG_ENABLE_IRQ_ISR
     io_handle->IRQQueue = NULL;


### PR DESCRIPTION
`pn532_is_ready` should be set to NULL to avoid an attempt to call it from `pn532_wait_ready` -> `pn532_poll_ready`, to avoid an Instruction Access Fault