### PR TITLE
Change the pn532_release_driver to public mode to restart allocation in some uses.

### DIFF
--- a/include/pn532_driver_hsu.h
+++ b/include/pn532_driver_hsu.h
@@ -11,13 +11,15 @@ extern "C"
 {
 #endif
 
-esp_err_t pn532_new_driver_hsu(gpio_num_t uart_rx,
-                               gpio_num_t uart_tx,
-                               gpio_num_t reset,
-                               gpio_num_t irq,
-                               uart_port_t uart_port,
-                               int32_t baudrate,
-                               pn532_io_handle_t io_handle);
+    esp_err_t pn532_new_driver_hsu(gpio_num_t uart_rx,
+                                   gpio_num_t uart_tx,
+                                   gpio_num_t reset,
+                                   gpio_num_t irq,
+                                   uart_port_t uart_port,
+                                   int32_t baudrate,
+                                   pn532_io_handle_t io_handle);
+
+    void pn532_release_driver(pn532_io_handle_t io_handle);
 
 #ifdef __cplusplus
 }

--- a/include/pn532_driver_i2c.h
+++ b/include/pn532_driver_i2c.h
@@ -18,7 +18,9 @@ extern "C"
                                    i2c_port_num_t i2c_port_number,
                                    pn532_io_handle_t io_handle);
 
-#ifdef __cplusplus
+    void pn532_release_driver(pn532_io_handle_t io_handle);
+
+    #ifdef __cplusplus
 }
 #endif
 


### PR DESCRIPTION
…in some uses.