### PR TITLE
Advanced I2C api

### DIFF
--- a/examples/flexible_i2c/CMakeLists.txt
+++ b/examples/flexible_i2c/CMakeLists.txt
@@ -1,0 +1,8 @@
+# For more information about build system see
+# https://docs.espressif.com/projects/esp-idf/en/latest/api-guides/build-system.html
+# The following five lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.16)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(flexible_i2c)

--- a/examples/flexible_i2c/main/CMakeLists.txt
+++ b/examples/flexible_i2c/main/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "ntag_read.c"
+                    INCLUDE_DIRS ".")

--- a/examples/flexible_i2c/main/flexible_i2c.c
+++ b/examples/flexible_i2c/main/flexible_i2c.c
@@ -1,0 +1,167 @@
+/**
+ * @file flexible_i2c.c
+ * @brief An example showing how to install the driver onto an existing I2C BUS.
+ * 
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <esp_log.h>
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#include "sdkconfig.h"
+#include "pn532_driver_i2c.h"
+#include "pn532_driver_hsu.h"
+#include "pn532_driver_spi.h"
+#include "pn532.h"
+
+
+
+// I2C mode needs only SDA, SCL and IRQ pins. RESET pin will be used if valid.
+// IRQ pin can be used in polling mode or in interrupt mode. Use menuconfig to select mode.
+#define SCL_PIN    (0)
+#define SDA_PIN    (1)
+#define RESET_PIN  (-1)
+#define IRQ_PIN    (3)
+
+
+static const char *TAG = "flexible_i2c";
+
+void app_main()
+{
+    pn532_io_t pn532_io;
+    esp_err_t err;
+
+    printf("APP MAIN\n");
+
+#if 0
+    // Enable DEBUG logging
+    esp_log_level_set("PN532", ESP_LOG_DEBUG);
+    esp_log_level_set("pn532_driver", ESP_LOG_DEBUG);
+    esp_log_level_set("pn532_driver_i2c", ESP_LOG_DEBUG);
+    esp_log_level_set("i2c.master", ESP_LOG_DEBUG);
+    esp_log_level_set("pn532_driver_hsu", ESP_LOG_DEBUG);
+    esp_log_level_set("pn532_driver_spi", ESP_LOG_DEBUG);
+    esp_log_level_set("spi", ESP_LOG_DEBUG);
+#endif
+
+    vTaskDelay(1000 / portTICK_PERIOD_MS);
+
+
+    
+    
+    i2c_master_bus_handle_t i2c_bus;
+    i2c_master_bus_config_t i2c_bus_config = {
+        .clk_source = I2C_CLK_SRC_DEFAULT,
+        .i2c_port = 0,
+        .sda_io_num = SDA_PIN,
+        .scl_io_num = SCL_PIN,
+        .glitch_ignore_cnt = 0,
+        .flags.enable_internal_pullup = true,
+    };
+
+    ESP_ERROR_CHECK(i2c_new_master_bus(&i2c_bus_config, &i2c_bus));
+
+    
+    
+    ESP_LOGI(TAG, "init PN532 in I2C mode");
+    pn532_gpio_conf_t rfid_gpio_conf = {
+        .reset = RESET_PIN,
+        .irq = IRQ_PIN
+    };
+
+    ESP_ERROR_CHECK(pn532_new_driver_i2c_ext(&pn532_io, rfid_gpio_conf, i2c_bus));
+
+
+    do {
+        err = pn532_init(&pn532_io);
+        if (err != ESP_OK) {
+            ESP_LOGW(TAG, "failed to initialize PN532");
+            pn532_release(&pn532_io);
+            vTaskDelay(1000 / portTICK_PERIOD_MS);
+        }
+    } while(err != ESP_OK);
+
+    ESP_LOGI(TAG, "get firmware version");
+    uint32_t version_data = 0;
+    do {
+        err = pn532_get_firmware_version(&pn532_io, &version_data);
+        if (ESP_OK != err) {
+            ESP_LOGI(TAG, "Didn't find PN53x board");
+            pn532_reset(&pn532_io);
+            vTaskDelay(1000 / portTICK_PERIOD_MS);
+        }
+    } while (ESP_OK != err);
+
+    // Log firmware infos
+    ESP_LOGI(TAG, "Found chip PN5%x", (unsigned int)(version_data >> 24) & 0xFF);
+    ESP_LOGI(TAG, "Firmware ver. %d.%d", (int)(version_data >> 16) & 0xFF, (int)(version_data >> 8) & 0xFF);
+
+    ESP_LOGI(TAG, "Waiting for an ISO14443A Card ...");
+    while (1)
+    {
+        uint8_t uid[] = {0, 0, 0, 0, 0, 0, 0}; // Buffer to store the returned UID
+        uint8_t uid_length;                     // Length of the UID (4 or 7 bytes depending on ISO14443A card type)
+
+        // Wait for an ISO14443A type cards (Mifare, etc.).  When one is found
+        // 'uid' will be populated with the UID, and uid_length will indicate
+        // if the uid is 4 bytes (Mifare Classic) or 7 bytes (Mifare Ultralight)
+        err = pn532_read_passive_target_id(&pn532_io, PN532_BRTY_ISO14443A_106KBPS, uid, &uid_length, 0);
+
+        if (ESP_OK == err)
+        {
+            // Display some basic information about the card
+            ESP_LOGI(TAG, "\nFound an ISO14443A card");
+            ESP_LOGI(TAG, "UID Length: %d bytes", uid_length);
+            ESP_LOGI(TAG, "UID Value:");
+            ESP_LOG_BUFFER_HEX_LEVEL(TAG, uid, uid_length, ESP_LOG_INFO);
+
+            err = pn532_in_list_passive_target(&pn532_io);
+            if (err != ESP_OK) {
+                ESP_LOGI(TAG, "Failed to inList passive target");
+                continue;
+            }
+
+            NTAG2XX_MODEL ntag_model = NTAG2XX_UNKNOWN;
+            err = ntag2xx_get_model(&pn532_io, &ntag_model);
+            if (err != ESP_OK)
+                continue;
+
+            int page_max;
+            switch (ntag_model) {
+                case NTAG2XX_NTAG213:
+                    page_max = 45;
+                    ESP_LOGI(TAG, "found NTAG213 target (or maybe NTAG203)");
+                    break;
+
+                case NTAG2XX_NTAG215:
+                    page_max = 135;
+                    ESP_LOGI(TAG, "found NTAG215 target");
+                    break;
+
+                case NTAG2XX_NTAG216:
+                    page_max = 231;
+                    ESP_LOGI(TAG, "found NTAG216 target");
+                    break;
+
+                default:
+                    ESP_LOGI(TAG, "Found unknown NTAG target!");
+                    continue;
+            }
+
+            for(int page=0; page < page_max; page+=4) {
+                uint8_t buf[16];
+                err = ntag2xx_read_page(&pn532_io, page, buf, 16);
+                if (err == ESP_OK) {
+                    ESP_LOG_BUFFER_HEXDUMP(TAG, buf, 16, ESP_LOG_INFO);
+                }
+                else {
+                    ESP_LOGI(TAG, "Failed to read page %d", page);
+                    break;
+                }
+            }
+            vTaskDelay(1000 / portTICK_PERIOD_MS);
+        }
+    }
+}

--- a/examples/flexible_i2c/main/idf_component.yml
+++ b/examples/flexible_i2c/main/idf_component.yml
@@ -1,0 +1,4 @@
+dependencies:
+  garag/esp-idf-pn532:
+    version: "*"
+    override_path: '../../../'

--- a/include/pn532_driver.h
+++ b/include/pn532_driver.h
@@ -55,9 +55,7 @@ struct pn532_io_t {
  */
 typedef struct pn532_gpio_conf_t {
     gpio_num_t reset;
-#ifdef CONFIG_ENABLE_IRQ_ISR
     gpio_num_t irq;
-#endif
 } pn532_gpio_conf_t;
 
 /**

--- a/include/pn532_driver.h
+++ b/include/pn532_driver.h
@@ -50,6 +50,17 @@ struct pn532_io_t {
 };
 
 /**
+ * @brief Structure containing GPIOs that are common among all drivers (SPI, I2C, UART)
+ * 
+ */
+typedef struct pn532_gpio_conf_t {
+    gpio_num_t reset;
+#ifdef CONFIG_ENABLE_IRQ_ISR
+    gpio_num_t irq;
+#endif
+} pn532_gpio_conf_t;
+
+/**
  * Initialize PN532 RFID module
  * @param io_handle PN532 io handle
  * @return ESP_OK if successful
@@ -125,6 +136,39 @@ esp_err_t pn532_send_command_wait_ack(pn532_io_handle_t io_handle, const uint8_t
  * @return ESP_OK if successful
  */
 esp_err_t pn532_read_ack(pn532_io_handle_t io_handle);
+
+
+/**
+ * @brief Installs IRQ service.
+ * @details Might be used during initialization or after
+ *          disabling it so that the same interrupt pin
+ *          could be used for waking the processor after
+ *          it eneters low power mode.
+ * 
+ * @param io_handle PN532 io handle
+ * @retval ESP_OK when operation successful
+ */
+esp_err_t pn532_enable_irq(pn532_io_handle_t io_handle);
+
+/**
+ * @brief Disables IRQ service.
+ * @details Might be used before entering deep sleep mode,
+ *          so that the same interrupt pin might wake the
+ *          processor.
+ * 
+ * @param io_handle PN532 io handle
+ * @retval ESP_OK when operation successful
+ */
+esp_err_t pn532_disable_irq(pn532_io_handle_t io_handle);
+
+/**
+ * @brief Checks if configuration is valid.
+ * 
+ * @param config Common pin configuration
+ * @retval ESP_OK if all data is correct
+ * @retval ESP_ERR_INVALID_ARG if any field is incorrect
+ */
+esp_err_t pn532_gpio_conf_check_validity(pn532_gpio_conf_t config);
 
 #ifdef __cplusplus
 }

--- a/include/pn532_driver_i2c.h
+++ b/include/pn532_driver_i2c.h
@@ -17,6 +17,20 @@ extern "C"
                                    gpio_num_t irq,
                                    i2c_port_num_t i2c_port_number,
                                    pn532_io_handle_t io_handle);
+    
+    /**
+     * @brief A flexible I2C driver that can utilize existing I2C bus.
+     * 
+     * @param io_handle Handle to device.
+     * @param gpio_config Configuration of GPIO pins that is common for all drivers.
+     * @param bus_handle Handle to I2C bus.
+     * @return esp_err_t 
+     */
+    esp_err_t pn532_new_driver_i2c_ext(
+        pn532_io_handle_t io_handle,
+        pn532_gpio_conf_t gpio_config,
+        i2c_master_bus_handle_t bus_handle
+    );
 
 #ifdef __cplusplus
 }

--- a/src/pn532_driver.c
+++ b/src/pn532_driver.c
@@ -450,11 +450,9 @@ esp_err_t pn532_gpio_conf_check_validity(pn532_gpio_conf_t config) {
   if (config.reset == GPIO_NUM_NC) {
     ret = ESP_ERR_INVALID_ARG;
   } 
-#ifdef CONFIG_ENABLE_IRQ_ISR
   else if (config.irq == GPIO_NUM_NC) {
     ret = ESP_ERR_INVALID_ARG;
   }
-#endif
 
   return ret;
 }

--- a/src/pn532_driver_i2c.c
+++ b/src/pn532_driver_i2c.c
@@ -91,9 +91,7 @@ esp_err_t pn532_new_driver_i2c_ext(pn532_io_handle_t io_handle,
     }
 
     io_handle->reset = gpio_config.reset;
-#ifdef CONFIG_ENABLE_IRQ_ISR
     io_handle->irq = gpio_config.irq;
-#endif
 
     pn532_i2c_driver_config *dev_config = heap_caps_calloc(1, sizeof(pn532_i2c_driver_config), MALLOC_CAP_DEFAULT);
     if (dev_config == NULL) {


### PR DESCRIPTION
Current version of the library is not very flexible in regards to using the device on existing data buses. For now I added new I2C driver creation function that utilizes a bus provided by user. These changes do not break current API but extend it for more complex use cases. There is possibility to make similar addition for SPI.

I also added convenience functions for enabling and disabling ISR service. My intension was to give user an ability to disable the interrupt before entering deep sleep mode so that  the very same interrupt pin could be used to wake up the processor.