### PR TITLE
Update idf_component.yml to idf version 5.1.3

### DIFF
--- a/idf_component.yml
+++ b/idf_component.yml
@@ -9,7 +9,7 @@ tags:
   - mifare
   - ntag
 dependencies:
-  idf: "^5.2"
+  idf: "^5.1"
 
 files:
   exclude:


### PR DESCRIPTION
This update modifies the library to support ESP-IDF starting from version 5.1, ensuring compatibility with both 5.1.x and later versions.